### PR TITLE
SCSS Fix in Vue Component "Default Sidebar"

### DIFF
--- a/klb-vue-publish.sh
+++ b/klb-vue-publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 set -e
-pnpm run build:klb
+npx pnpm run build:klb
 cd packages/klb-vue/dist
 
 npm publish --access public

--- a/packages/klb-vue/package.json
+++ b/packages/klb-vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@karpeleslab/klb-vue",
-    "version": "0.0.109",
+    "version": "0.0.111",
     "author": "Florian 'Fy' Gasquez <m@fy.to>",
     "license": "MIT",
     "repository": {

--- a/packages/klb-vue/package.json
+++ b/packages/klb-vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@karpeleslab/klb-vue",
-    "version": "0.0.111",
+    "version": "0.0.112",
     "author": "Florian 'Fy' Gasquez <m@fy.to>",
     "license": "MIT",
     "repository": {

--- a/packages/klb-vue/package.json
+++ b/packages/klb-vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@karpeleslab/klb-vue",
-    "version": "0.0.113",
+    "version": "0.0.114",
     "author": "Florian 'Fy' Gasquez <m@fy.to>",
     "license": "MIT",
     "repository": {

--- a/packages/klb-vue/package.json
+++ b/packages/klb-vue/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@fy-/klb-vue",
+    "name": "@karpeleslab/klb-vue",
     "version": "0.0.109",
     "author": "Florian 'Fy' Gasquez <m@fy.to>",
     "license": "MIT",

--- a/packages/klb-vue/package.json
+++ b/packages/klb-vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@karpeleslab/klb-vue",
-    "version": "0.0.112",
+    "version": "0.0.113",
     "author": "Florian 'Fy' Gasquez <m@fy.to>",
     "license": "MIT",
     "repository": {

--- a/packages/klb-vue/package.json
+++ b/packages/klb-vue/package.json
@@ -5,12 +5,12 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/fy-to/FWJS.git"
+        "url": "git+https://github.com/KarpelesLab/FWJS.git"
     },
     "bugs": {
-        "url": "https://github.com/fy-to/FWJS/issues"
+        "url": "https://github.com/KarpelesLab/FWJS/issues"
     },
-    "homepage": "https://github.com/fy-to/FWJS#readme",
+    "homepage": "https://github.com/KarpelesLab/FWJS#readme",
     "main": "src/index.ts",
     "module": "src/index.ts",
     "typings": "src/index.ts",

--- a/packages/klb-vue/src/composables/KlbAgentSpeech.ts
+++ b/packages/klb-vue/src/composables/KlbAgentSpeech.ts
@@ -40,7 +40,9 @@ export function useKlbAgentSpeech(language = "en-US") {
   const getSession = async (agentId: string) => {
     eventBus.emit("main-loading", true);
     sessionStarted.value = true;
-    const r = await rest(`HIAgent/${agentId}/Session:get`, "GET", {_expand: "/HIAgent"});
+    const r = await rest(`HIAgent/${agentId}/Session:get`, "GET", {
+      _expand: "/HIAgent",
+    });
 
     if (r && r.result == "success") {
       sessionData.value = r.data.Session;

--- a/packages/klb-vue/src/composables/speechRecognition.ts
+++ b/packages/klb-vue/src/composables/speechRecognition.ts
@@ -28,7 +28,7 @@ export function useSpeechRecognition(
       onTextAvailableCallback(transcript);
       transcript = "";
     } else {
-      recognition.start()
+      recognition.start();
     }
   };
 

--- a/packages/klb-vue/src/composables/speechRecognition.ts
+++ b/packages/klb-vue/src/composables/speechRecognition.ts
@@ -23,8 +23,8 @@ export function useSpeechRecognition(
   };
 
   recognition.onend = () => {
-    isRecording.value = false;
     if (transcript) {
+      isRecording.value = false;
       onTextAvailableCallback(transcript);
       transcript = "";
     }

--- a/packages/klb-vue/src/composables/speechRecognition.ts
+++ b/packages/klb-vue/src/composables/speechRecognition.ts
@@ -48,6 +48,10 @@ export function useSpeechRecognition(
     }
   };
 
+  const changeLanguage = (newLanguage: string) => {
+    recognition.lang = newLanguage;
+  };
+
   const startRecording = () => {
     if (
       !("SpeechRecognition" in window || "webkitSpeechRecognition" in window)
@@ -86,5 +90,6 @@ export function useSpeechRecognition(
     stopRecording,
     isRecording,
     resumeRecording,
+    changeLanguage,
   };
 }

--- a/packages/klb-vue/src/composables/speechRecognition.ts
+++ b/packages/klb-vue/src/composables/speechRecognition.ts
@@ -27,6 +27,8 @@ export function useSpeechRecognition(
       isRecording.value = false;
       onTextAvailableCallback(transcript);
       transcript = "";
+    } else {
+      recognition.start()
     }
   };
 

--- a/packages/klb-vue/src/stores/user.ts
+++ b/packages/klb-vue/src/stores/user.ts
@@ -58,7 +58,8 @@ export function useUserCheck(path = "/login", redirectLink = false) {
         if (!redirectLink) router.push(path);
         else {
           router.status = 307;
-          router.push(`${path}?return_to=${route.fullPath}`);
+          // encodeURIComponent because while the documentation says fullPath is percent encoded, that is a big fat lie
+          router.push(`${path}?return_to=${encodeURIComponent(route.fullPath)}`);
         }
       }
     }

--- a/packages/klb-vue/src/stores/user.ts
+++ b/packages/klb-vue/src/stores/user.ts
@@ -58,7 +58,7 @@ export function useUserCheck(path = "/login", redirectLink = false) {
         if (!redirectLink) router.push(path);
         else {
           router.status = 307;
-          router.push(`${path}?return_to=${route.path}`);
+          router.push(`${path}?return_to=${route.fullPath}`);
         }
       }
     }

--- a/packages/klb-vue/src/stores/user.ts
+++ b/packages/klb-vue/src/stores/user.ts
@@ -59,7 +59,9 @@ export function useUserCheck(path = "/login", redirectLink = false) {
         else {
           router.status = 307;
           // encodeURIComponent because while the documentation says fullPath is percent encoded, that is a big fat lie
-          router.push(`${path}?return_to=${encodeURIComponent(route.fullPath)}`);
+          router.push(
+            `${path}?return_to=${encodeURIComponent(route.fullPath)}`,
+          );
         }
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       vue:
         specifier: ^3.3.13
         version: 3.4.26(typescript@5.4.5)
+      vue-picture-cropper:
+        specifier: ^0.7.0
+        version: 0.7.0(vue@3.4.26)
       vue-router:
         specifier: ^4.2.5
         version: 4.3.2(vue@3.4.26)


### PR DESCRIPTION
1 line SCSS fix to avoid the following error: 

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in `& {}`. More info: https://sass-lang.com/d/mixed-decls
   ╷
22 │ ┌     span {
23 │ │       @apply whitespace-nowrap;
24 │ │     }
   │ └─── nested rule
25 │       transition: all 300ms ease-in-out;
   │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
   ╵
in /@fy-/klb-vue/components/ui/DefaultSidebar.vue 25:5
```